### PR TITLE
Add instructions for getting set up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ABLY_API_KEY=your-ably-api-key

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ The Ably Playground is a (very work-in-progress) showcase of the many use-cases 
 ## Getting set up
 
 1. Clone the repo to your local machine
-2. Run `cp .env.example .env`
-3. Add your Ably api key to the `.env`
-4. Start the server with `npm run server`
-5. Start the client with `npm run client`
+2. In your teminal, run `cp .env.example .env`
+3. Add your Ably API key to the `.env`
+4. Install packages with `npm install`
+5. Start the server with `npm run server`
+6. In a new window, start the client with `npm run client`

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Ably playground
+The Ably Playground is a (very work-in-progress) showcase of the many use-cases you can power with Ably and other great tools.
+
+## Getting set up
+
+1. Clone the repo to your local machine
+2. Run `cp .env.example .env`
+3. Add your Ably api key to the `.env`
+4. Start the server with `npm run server`
+5. Start the client with `npm run client`

--- a/api/index.js
+++ b/api/index.js
@@ -3,6 +3,8 @@ const bodyParser = require('body-parser')
 const path = require('path')
 const Ably = require('ably')
 
+require('dotenv').config()
+
 const app = express()
 const port = process.env.PORT || 8000
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "autoprefixer": "^10.4.2",
+        "dotenv": "^16.0.0",
         "postcss": "^8.4.7",
         "tailwindcss": "^3.0.23"
       }
@@ -6462,11 +6463,12 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dotenv-expand": {
@@ -13597,6 +13599,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readable-stream": {
@@ -21043,9 +21053,10 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -26072,6 +26083,13 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        }
       }
     },
     "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "client": "react-scripts start",
     "server": "node api/index.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.2",
+    "dotenv": "^16.0.0",
     "postcss": "^8.4.7",
     "tailwindcss": "^3.0.23"
   }


### PR DESCRIPTION
We were missing a README to help others folks get set up. I've created something super small for now, and I've made things a little easier to work with by installing `dotenv` and adding en example `.env` file for folks to copy.